### PR TITLE
fix: Simplify Part 1 instructions - single customization point

### DIFF
--- a/exercises/part1-setup.md
+++ b/exercises/part1-setup.md
@@ -113,12 +113,9 @@ docker push $ACR_NAME.azurecr.io/workshop-api:v1.0.0
 cd ../..
 ```
 
-Or use the provided script:
-```bash
-./scripts/build-and-push-api.sh $ACR_NAME v1.0.0
-```
+> **Note:** This builds the Docker image from the FastAPI application source code and pushes it to your Azure Container Registry. The build process typically takes 1-2 minutes.
 
----
+------
 
 ## Step 6: Deploy Infrastructure
 


### PR DESCRIPTION
## Changes

This PR further simplifies Part 1 instructions by consolidating naming and removing alternatives.

### What Changed

1. **Single customization point for naming** (Step 3)
   - Users only customize  (e.g., "srepk")
   -  is automatically derived: `${BASE_NAME}-workshop`
   - Eliminates confusion and potential mismatches between names
   - Updated Quick Reference section to match

2. **Removed script alternative in Step 5**
   - Only manual Docker build/push commands now
   - Makes it clear exactly what's happening
   - Better for learning and troubleshooting

### Benefits

- **Simpler setup**: Only one variable to customize instead of two
- **Consistency**: Resource group name automatically matches base name
- **Clarity**: Manual commands show exactly what happens (no hidden scripts)
- **Less error-prone**: Reduces chance of name mismatches

### Example

**Before:**
```bash
RESOURCE_GROUP="sre-workshop-pk"
BASE_NAME="srepk"
```

**After:**
```bash
BASE_NAME="srepk"
RESOURCE_GROUP="${BASE_NAME}-workshop"  # Automatically: srepk-workshop
```

cc: @pelithne